### PR TITLE
Add automatic redirect from glebkalinin.ru to glebkalinin.com

### DIFF
--- a/themes/gk/layout/_partial/head.ejs
+++ b/themes/gk/layout/_partial/head.ejs
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <script>
+    // Redirect from glebkalinin.ru to glebkalinin.com
+    if (window.location.hostname === 'glebkalinin.ru') {
+      window.location.replace(window.location.href.replace('glebkalinin.ru', 'glebkalinin.com'));
+    }
+  </script>
   <meta charset="utf-8">
   <%
   var title = page.title;


### PR DESCRIPTION
Added JavaScript redirect script in the head template that checks if the current hostname is glebkalinin.ru and automatically redirects to glebkalinin.com while preserving the full URL path. This ensures users always land on the .com domain regardless of which domain they access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)